### PR TITLE
stack.yaml default file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,12 @@
+resolver: nightly-2020-01-31
+
+packages:
+- '.'
+- ./haskell-lsp-types
+
+extra-deps:
+
+flags: {}
+extra-package-dbs: []
+nix:
+  packages: [icu]


### PR DESCRIPTION
I wanted to give the project a try and figure out the bindings with the example language server. The instructions (`stack install :lsp-hello --flag haskell-lsp:demo`) won't work because there is no `stack.yaml` actually named that way. To have the project working by default with stack an existing `stack.yaml` might be helpful.

Otherwise we could extend the instructions to clarify that a stack-<version>.yaml has to be copied or provided as argument.
