### PR TITLE
Fix deriving instance of MonadUnliftIO

### DIFF
--- a/lsp.cabal
+++ b/lsp.cabal
@@ -54,7 +54,7 @@ library
                      , transformers >= 0.5.6 && < 0.6
                      , time
                      , unordered-containers
-                     , unliftio-core
+                     , unliftio-core >= 0.2.0.0
                      -- used for generating random uuids for dynamic registration
                      , random
                      , uuid >= 1.3

--- a/src/Language/LSP/Server/Core.hs
+++ b/src/Language/LSP/Server/Core.hs
@@ -20,6 +20,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RecursiveDo #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fprint-explicit-kinds #-}
 
@@ -72,15 +73,10 @@ import           Control.Monad.Trans.Identity
 -- ---------------------------------------------------------------------
 
 newtype LspT config m a = LspT { unLspT :: ReaderT (LanguageContextEnv config) m a }
-  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadFix)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadUnliftIO, MonadFix)
 
--- Manually deriving LspT as an instance of MonadUnliftIO
-instance MonadUnliftIO m => MonadUnliftIO (LspT config m) where 
-  withRunInIO inner = 
-    LspT $ 
-    ReaderT $ \config -> 
-      withRunInIO $ \run -> 
-        inner (run . flip runReaderT config . unLspT)
+-- for deriving the instance of MonadUnliftIO
+type role LspT representational representational nominal
 
 runLspT :: LanguageContextEnv config -> LspT config m a -> m a
 runLspT env = flip runReaderT env . unLspT

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -10,6 +10,7 @@ extra-deps:
 - dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
 - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
 - dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
+- unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 - github: bubba/lsp-test
   commit: e251176a4b2ff4dead7846fe5d0a4e1dbea69fd4
 

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -10,6 +10,7 @@ extra-deps:
 - dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
 - constraints-extras-0.3.0.2@sha256:013b8d0392582c6ca068e226718a4fe8be8e22321cc0634f6115505bf377ad26,1853
 - dependent-sum-0.7.1.0@sha256:5599aa89637db434431b1dd3fa7c34bc3d565ee44f0519bfbc877be1927c2531,2068
+- unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
 - github: bubba/lsp-test
   commit: e251176a4b2ff4dead7846fe5d0a4e1dbea69fd4
 


### PR DESCRIPTION
Somehow, the auto deriving magic doesn't work, when building the project using Stack (sorry).

```
 src/Language/LSP/Server/Core.hs:75:63: error:
     • Couldn't match representation of type ‘m (UnliftIO
                                                   (LspT config m))’
                                with that of ‘m (UnliftIO (ReaderT (LanguageContextEnv config) m))’
         arising from the coercion of the method ‘askUnliftIO’
           from type ‘ReaderT
                        (LanguageContextEnv config)
                        m
                        (UnliftIO (ReaderT (LanguageContextEnv config) m))’
             to type ‘LspT config m (UnliftIO (LspT config m))’
       NB: We cannot know what roles the parameters to ‘m’ have;
         we must assume that the role is nominal
     • When deriving the instance for (MonadUnliftIO (LspT config m))
    |
 75 |   deriving (Functor, Applicative, Monad, MonadIO, MonadTrans, MonadUnliftIO, MonadFix)
    |                                                               ^^^^^^^^^^^^^
```

So I followed [MonadUnliftIO's example](https://github.com/fpco/unliftio/tree/master/unliftio#examples) and derived it manually instead.

```haskell
-- Manually deriving LspT as an instance of MonadUnliftIO
instance MonadUnliftIO m => MonadUnliftIO (LspT config m) where 
  withRunInIO inner = 
    LspT $ 
    ReaderT $ \config -> 
      withRunInIO $ \run -> 
        inner (run . flip runReaderT config . unLspT)
```