### PR TITLE
Add proper support for prepareRename

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Message.hs
+++ b/lsp-types/src/Language/LSP/Types/Message.hs
@@ -193,7 +193,7 @@ type family ResponseResult (m :: Method f Request) :: Type where
   ResponseResult TextDocumentOnTypeFormatting  = List TextEdit
   -- Rename
   ResponseResult TextDocumentRename            = WorkspaceEdit
-  ResponseResult TextDocumentPrepareRename     = Range |? RangeWithPlaceholder
+  ResponseResult TextDocumentPrepareRename     = Maybe (Range |? RangeWithPlaceholder)
   -- FoldingRange
   ResponseResult TextDocumentFoldingRange      = List FoldingRange
   ResponseResult TextDocumentSelectionRange    = List SelectionRange


### PR DESCRIPTION
There are two commits here.

The first commit fixes #264 by allowing a `null` response to `prepareRename`.

The second commit actually correctly sets `prepareProvider` in `RenameOptions` if the client has `prepareSupport` and the server provides a `TextDocumentPrepareRename` handler.

I checked that this works with VSCodium. If I try to rename a keyword and the server returns `Nothing` from the prepare handler, the UX reacts by showing a predefined error message, as expected:

![image](https://user-images.githubusercontent.com/451835/100307396-ba672b00-2f73-11eb-9e61-c1ee94961df0.png)