### PR TITLE
Add support for file and folder operations (create, rename, move) to workspace edits

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,8 +8,8 @@ package lsp
 
 source-repository-package
     type: git
-    location: https://github.com/wz1000/lsp-test.git
-    tag: d1ecbc5e8f324895701293429976a6c2f74d82a2
+    location: https://github.com/bubba/lsp-test.git
+    tag: cd644f52c5c564403b5f3b0a8652e7f4154f8d6a
 
 tests: True
 test-show-details: direct

--- a/example/Reactor.hs
+++ b/example/Reactor.hs
@@ -225,7 +225,7 @@ handle = mconcat
       let edit = J.TextEdit (J.mkRange l c l (c + T.length newName)) newName
           tde = J.TextDocumentEdit vdoc (J.List [edit])
           -- "documentChanges" field is preferred over "changes"
-          rsp = J.WorkspaceEdit Nothing (Just (J.List [tde]))
+          rsp = J.WorkspaceEdit Nothing (Just (J.List [J.InL tde]))
       responder (Right rsp)
 
   , requestHandler J.STextDocumentHover $ \req responder -> do

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -257,7 +257,6 @@ makeFieldsNoPrefix ''DocumentFilter
 makeFieldsNoPrefix ''TextEdit
 makeFieldsNoPrefix ''VersionedTextDocumentIdentifier
 makeFieldsNoPrefix ''TextDocumentEdit
-makeFieldsNoPrefix ''FileResourceChangeKind
 makeFieldsNoPrefix ''CreateFileOptions
 makeFieldsNoPrefix ''CreateFile
 makeFieldsNoPrefix ''RenameFileOptions

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -257,6 +257,13 @@ makeFieldsNoPrefix ''DocumentFilter
 makeFieldsNoPrefix ''TextEdit
 makeFieldsNoPrefix ''VersionedTextDocumentIdentifier
 makeFieldsNoPrefix ''TextDocumentEdit
+makeFieldsNoPrefix ''FileResourceChangeKind
+makeFieldsNoPrefix ''CreateFileOptions
+makeFieldsNoPrefix ''CreateFile
+makeFieldsNoPrefix ''RenameFileOptions
+makeFieldsNoPrefix ''RenameFile
+makeFieldsNoPrefix ''DeleteFileOptions
+makeFieldsNoPrefix ''DeleteFile
 makeFieldsNoPrefix ''WorkspaceEdit
 
 -- Workspace Folders

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -58,7 +58,7 @@ deriveJSON lspOptions ''CreateFileOptions
 data CreateFile =
   CreateFile
     { -- | The resource to create.
-      _uri      :: Text
+      _uri      :: Uri
       -- | Additional options
     , _options  :: Maybe CreateFileOptions
     } deriving (Show, Read, Eq)
@@ -95,9 +95,9 @@ deriveJSON lspOptions ''RenameFileOptions
 data RenameFile =
   RenameFile
     { -- | The old (existing) location.
-      _oldUri   :: Text
+      _oldUri   :: Uri
       -- | The new location.
-    , _newUri   :: Text
+    , _newUri   :: Uri
       -- | Rename options.
     , _options  :: Maybe RenameFileOptions
     } deriving (Show, Read, Eq)
@@ -136,7 +136,7 @@ deriveJSON lspOptions ''DeleteFileOptions
 data DeleteFile =
   DeleteFile
     { -- | The file to delete.
-      _uri      :: Text
+      _uri      :: Uri
       -- | Delete options.
     , _options  :: Maybe DeleteFileOptions
     } deriving (Show, Read, Eq)

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -38,6 +38,98 @@ deriveJSON lspOptions ''TextDocumentEdit
 
 -- ---------------------------------------------------------------------
 
+-- | For tagging `CreateFile`/`RenameFile`/`DeleteFile`
+-- Should this be merged with `ResourceOperationKind` ?
+data FileResourceChangeKind
+  = FileResourceChangeCreate
+  | FileResourceChangeRename
+  | FileResourceChangeDelete 
+  deriving (Read, Show, Eq)
+  
+instance ToJSON FileResourceChangeKind where
+  toJSON FileResourceChangeCreate = String "create"
+  toJSON FileResourceChangeRename = String "rename"
+  toJSON FileResourceChangeDelete = String "delete"
+
+instance FromJSON FileResourceChangeKind where
+  parseJSON (String "create") = pure FileResourceChangeCreate
+  parseJSON (String "rename") = pure FileResourceChangeRename
+  parseJSON (String "delete") = pure FileResourceChangeDelete
+  parseJSON _                 = mempty
+
+-- | Options to create a file.
+data CreateFileOptions =
+  CreateFileOptions
+    { -- | Overwrite existing file. Overwrite wins over `ignoreIfExists`
+      _overwrite      :: Bool
+      -- | Ignore if exists.
+    , _ignoreIfExists :: Bool
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''CreateFileOptions
+
+-- | Create file operation
+data CreateFile =
+  CreateFile
+    { _kind     :: FileResourceChangeKind
+      -- | The resource to create.
+    , _uri      :: Text
+      -- | Additional options
+    , _options  :: Maybe CreateFileOptions
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''CreateFile
+
+-- Rename file options
+data RenameFileOptions =
+  RenameFileOptions
+    { -- | Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+      _overwrite      :: Bool
+      -- | Ignores if target exists.
+    , _ignoreIfExists :: Bool
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''RenameFileOptions
+
+-- | Rename file operation
+data RenameFile =
+  RenameFile
+    { _kind     :: FileResourceChangeKind
+      -- | The old (existing) location.
+    , _oldUri   :: Text
+      -- | The new location.
+    , _newUri   :: Text
+      -- | Rename options.
+    , _options  :: Maybe RenameFileOptions
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''RenameFile
+
+-- Delete file options
+data DeleteFileOptions =
+  DeleteFileOptions
+    { -- | Delete the content recursively if a folder is denoted.
+      _recursive          :: Bool
+      -- | Ignore the operation if the file doesn't exist.
+    , _ignoreIfNotExists  :: Bool
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''DeleteFileOptions
+
+-- | Delete file operation
+data DeleteFile =
+  DeleteFile
+    { _kind     :: FileResourceChangeKind
+      -- | The file to delete.
+    , _uri      :: Text
+      -- | Delete options.
+    , _options  :: Maybe DeleteFileOptions
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''DeleteFile
+
+-- ---------------------------------------------------------------------
+
 type WorkspaceEditMap = H.HashMap Uri (List TextEdit)
 
 data WorkspaceEdit =

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -142,7 +142,7 @@ type WorkspaceEditMap = H.HashMap Uri (List TextEdit)
 data WorkspaceEdit =
   WorkspaceEdit
     { _changes         :: Maybe WorkspaceEditMap
-    , _documentChanges :: Maybe (List TextDocumentEdit)
+    , _documentChanges :: Maybe (List DocumentChange)
     } deriving (Show, Read, Eq)
 
 instance Semigroup WorkspaceEdit where

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -63,9 +63,9 @@ instance FromJSON FileResourceChangeKind where
 data CreateFileOptions =
   CreateFileOptions
     { -- | Overwrite existing file. Overwrite wins over `ignoreIfExists`
-      _overwrite      :: Bool
+      _overwrite      :: Maybe Bool
       -- | Ignore if exists.
-    , _ignoreIfExists :: Bool
+    , _ignoreIfExists :: Maybe Bool
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''CreateFileOptions
@@ -86,9 +86,9 @@ deriveJSON lspOptions ''CreateFile
 data RenameFileOptions =
   RenameFileOptions
     { -- | Overwrite target if existing. Overwrite wins over `ignoreIfExists`
-      _overwrite      :: Bool
+      _overwrite      :: Maybe Bool
       -- | Ignores if target exists.
-    , _ignoreIfExists :: Bool
+    , _ignoreIfExists :: Maybe Bool
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''RenameFileOptions
@@ -111,9 +111,9 @@ deriveJSON lspOptions ''RenameFile
 data DeleteFileOptions =
   DeleteFileOptions
     { -- | Delete the content recursively if a folder is denoted.
-      _recursive          :: Bool
+      _recursive          :: Maybe Bool
       -- | Ignore the operation if the file doesn't exist.
-    , _ignoreIfNotExists  :: Bool
+    , _ignoreIfNotExists  :: Maybe Bool
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''DeleteFileOptions

--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DuplicateRecordFields      #-}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE OverloadedStrings          #-}
+
 module Language.LSP.Types.WorkspaceEdit where
 
 import           Data.Aeson
@@ -127,6 +129,11 @@ data DeleteFile =
     } deriving (Show, Read, Eq)
 
 deriveJSON lspOptions ''DeleteFile
+
+-- ---------------------------------------------------------------------
+
+-- | `TextDocumentEdit |? CreateFile |? RenameFile |? DeleteFile` is a bit mouthful, here's the synonym
+type DocumentChange = TextDocumentEdit |? CreateFile |? RenameFile |? DeleteFile
 
 -- ---------------------------------------------------------------------
 

--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -162,6 +162,10 @@ applyRenameFile (J.RenameFile _ oldUri' newUri' options) vfs =
         Just (J.RenameFileOptions False _) -> False -- `overwrite` wins over `ignoreIfExists`
         Nothing                            -> False 
 
+-- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
+applyDeleteFile :: J.DeleteFile -> VFS -> VFS
+applyDeleteFile (J.DeleteFile _ uri _options) = 
+  updateVFS $ Map.delete (J.toNormalizedUri (J.Uri uri))
 
 -- ^ Applies the changes from a 'ApplyWorkspaceEditRequest' to the 'VFS'
 changeFromServerVFS :: VFS -> J.Message 'J.WorkspaceApplyEdit -> IO VFS

--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -138,9 +138,16 @@ applyCreateFile (J.CreateFile _ uri options) =
   where 
     shouldOverwrite :: Bool 
     shouldOverwrite = case options of 
-        Just (J.CreateFileOptions True  _) -> True  -- `overwrite` is True
-        Just (J.CreateFileOptions False _) -> False -- `overwrite` wins over `ignoreIfExists`
-        Nothing                            -> False 
+        Nothing                                               -> False  -- default
+        Just (J.CreateFileOptions Nothing       Nothing     ) -> False  -- default
+        Just (J.CreateFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True 
+        Just (J.CreateFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False 
+        Just (J.CreateFileOptions (Just True)   Nothing     ) -> True   -- `overwrite` is True
+        Just (J.CreateFileOptions (Just True)   (Just True) ) -> True   -- `overwrite` wins over `ignoreIfExists`
+        Just (J.CreateFileOptions (Just True)   (Just False)) -> True   -- `overwrite` is True
+        Just (J.CreateFileOptions (Just False)  Nothing     ) -> False  -- `overwrite` is False
+        Just (J.CreateFileOptions (Just False)  (Just True) ) -> False  -- `overwrite` is False
+        Just (J.CreateFileOptions (Just False)  (Just False)) -> False  -- `overwrite` wins over `ignoreIfExists`
 
 applyRenameFile :: J.RenameFile -> VFS -> VFS
 applyRenameFile (J.RenameFile _ oldUri' newUri' options) vfs = 
@@ -158,9 +165,16 @@ applyRenameFile (J.RenameFile _ oldUri' newUri' options) vfs =
   where 
     shouldOverwrite :: Bool 
     shouldOverwrite = case options of 
-        Just (J.RenameFileOptions True  _) -> True  -- `overwrite` is True
-        Just (J.RenameFileOptions False _) -> False -- `overwrite` wins over `ignoreIfExists`
-        Nothing                            -> False 
+        Nothing                                               -> False  -- default
+        Just (J.RenameFileOptions Nothing       Nothing     ) -> False  -- default
+        Just (J.RenameFileOptions Nothing       (Just True) ) -> False  -- `ignoreIfExists` is True 
+        Just (J.RenameFileOptions Nothing       (Just False)) -> True   -- `ignoreIfExists` is False 
+        Just (J.RenameFileOptions (Just True)   Nothing     ) -> True   -- `overwrite` is True
+        Just (J.RenameFileOptions (Just True)   (Just True) ) -> True   -- `overwrite` wins over `ignoreIfExists`
+        Just (J.RenameFileOptions (Just True)   (Just False)) -> True   -- `overwrite` is True
+        Just (J.RenameFileOptions (Just False)  Nothing     ) -> False  -- `overwrite` is False
+        Just (J.RenameFileOptions (Just False)  (Just True) ) -> False  -- `overwrite` is False
+        Just (J.RenameFileOptions (Just False)  (Just False)) -> False  -- `overwrite` wins over `ignoreIfExists`
 
 -- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
 applyDeleteFile :: J.DeleteFile -> VFS -> VFS

--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -133,7 +133,7 @@ applyCreateFile :: J.CreateFile -> VFS -> VFS
 applyCreateFile (J.CreateFile uri options) = 
   updateVFS $ Map.insertWith 
                 (\ new old -> if shouldOverwrite then new else old)
-                (J.toNormalizedUri (J.Uri uri))
+                (J.toNormalizedUri uri)
                 (VirtualFile 0 0 (Rope.fromText ""))
   where 
     shouldOverwrite :: Bool 
@@ -151,8 +151,8 @@ applyCreateFile (J.CreateFile uri options) =
 
 applyRenameFile :: J.RenameFile -> VFS -> VFS
 applyRenameFile (J.RenameFile oldUri' newUri' options) vfs = 
-  let oldUri = J.toNormalizedUri (J.Uri oldUri')
-      newUri = J.toNormalizedUri (J.Uri newUri')
+  let oldUri = J.toNormalizedUri oldUri'
+      newUri = J.toNormalizedUri newUri'
   in  case Map.lookup oldUri (vfsMap vfs) of 
         -- nothing to rename 
         Nothing -> vfs 
@@ -179,7 +179,7 @@ applyRenameFile (J.RenameFile oldUri' newUri' options) vfs =
 -- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
 applyDeleteFile :: J.DeleteFile -> VFS -> VFS
 applyDeleteFile (J.DeleteFile uri _options) = 
-  updateVFS $ Map.delete (J.toNormalizedUri (J.Uri uri))
+  updateVFS $ Map.delete (J.toNormalizedUri uri)
 
 
 applyTextDocumentEdit :: J.TextDocumentEdit -> VFS -> IO VFS

--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -130,7 +130,7 @@ updateVFS f vfs@VFS{vfsMap} = vfs { vfsMap = f vfsMap }
 -- ---------------------------------------------------------------------
 
 applyCreateFile :: J.CreateFile -> VFS -> VFS
-applyCreateFile (J.CreateFile _ uri options) = 
+applyCreateFile (J.CreateFile uri options) = 
   updateVFS $ Map.insertWith 
                 (\ new old -> if shouldOverwrite then new else old)
                 (J.toNormalizedUri (J.Uri uri))
@@ -150,7 +150,7 @@ applyCreateFile (J.CreateFile _ uri options) =
         Just (J.CreateFileOptions (Just False)  (Just False)) -> False  -- `overwrite` wins over `ignoreIfExists`
 
 applyRenameFile :: J.RenameFile -> VFS -> VFS
-applyRenameFile (J.RenameFile _ oldUri' newUri' options) vfs = 
+applyRenameFile (J.RenameFile oldUri' newUri' options) vfs = 
   let oldUri = J.toNormalizedUri (J.Uri oldUri')
       newUri = J.toNormalizedUri (J.Uri newUri')
   in  case Map.lookup oldUri (vfsMap vfs) of 
@@ -178,7 +178,7 @@ applyRenameFile (J.RenameFile _ oldUri' newUri' options) vfs =
 
 -- NOTE: we are ignoring the `recursive` option here because we don't know which file is a directory
 applyDeleteFile :: J.DeleteFile -> VFS -> VFS
-applyDeleteFile (J.DeleteFile _ uri _options) = 
+applyDeleteFile (J.DeleteFile uri _options) = 
   updateVFS $ Map.delete (J.toNormalizedUri (J.Uri uri))
 
 

--- a/src/Language/LSP/Server/Core.hs
+++ b/src/Language/LSP/Server/Core.hs
@@ -744,15 +744,16 @@ reverseSortEdit (J.WorkspaceEdit cs dcs) = J.WorkspaceEdit cs' dcs'
     cs' :: Maybe J.WorkspaceEditMap
     cs' = (fmap . fmap ) sortTextEdits cs
 
-    dcs' :: Maybe (J.List J.TextDocumentEdit)
-    dcs' = (fmap . fmap ) sortTextDocumentEdits dcs
+    dcs' :: Maybe (J.List J.DocumentChange)
+    dcs' = (fmap . fmap) sortOnlyTextDocumentEdits dcs
 
     sortTextEdits :: J.List J.TextEdit -> J.List J.TextEdit
     sortTextEdits (J.List edits) = J.List (L.sortBy down edits)
 
-    sortTextDocumentEdits :: J.TextDocumentEdit -> J.TextDocumentEdit
-    sortTextDocumentEdits (J.TextDocumentEdit td (J.List edits)) = J.TextDocumentEdit td (J.List edits')
+    sortOnlyTextDocumentEdits :: J.DocumentChange -> J.DocumentChange
+    sortOnlyTextDocumentEdits (J.InL (J.TextDocumentEdit td (J.List edits))) = J.InL $ J.TextDocumentEdit td (J.List edits')
       where
         edits' = L.sortBy down edits
+    sortOnlyTextDocumentEdits (J.InR others) = J.InR others
 
     down (J.TextEdit r1 _) (J.TextEdit r2 _) = r2 `compare` r1


### PR DESCRIPTION
Instead of having `TextDocumentEdit` in `WorkspaceEdit`

```haskell
data WorkspaceEdit =
  WorkspaceEdit
    { _changes         :: Maybe WorkspaceEditMap
    , _documentChanges :: Maybe (List TextDocumentEdit)
    } deriving (Show, Read, Eq)
```

It is now replaced by a new type called `DocumentChange`

```haskell
data WorkspaceEdit =
  WorkspaceEdit
    { _changes         :: Maybe WorkspaceEditMap
    , _documentChanges :: Maybe (List DocumentChange)
    } deriving (Show, Read, Eq)
```

Which is just a synonym of union of `WorkspaceEdit` and other operations

```haskell
type DocumentChange = TextDocumentEdit |? CreateFile |? RenameFile |? DeleteFile
```

So that it complies with the [spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspaceEdit) as suggested by @EggBaconAndSpam in https://github.com/alanz/lsp/issues/134#issuecomment-502025882

---

Here's how to construct a `DocumentChange` that creates a file for example: 
```haskell
InR (InL (CreateFile FileResourceChangeCreate "/path/to/new/file" Nothing))
```

But it's a bit wordy and unsafe because of the `FileResoureChangeKind`.
I'm considering hiding these constructors and export only smart constructors.