### PR TITLE
Tighten bounds on dependent-sum

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -84,6 +84,7 @@ library
                      , scientific
                      , some
                      , dependent-sum-template
+                     , dependent-sum >= 0.6.2.2
                      , text
                      , template-haskell
                      , temporary

--- a/lsp-types/src/Language/LSP/Types/Method.hs
+++ b/lsp-types/src/Language/LSP/Types/Method.hs
@@ -16,7 +16,7 @@ import           Data.Text                                  (Text)
 import           Language.LSP.Types.Utils
 import           Data.Function (on)
 import Control.Applicative
-import  Data.GADT.Compare.TH
+import Data.GADT.Compare.TH
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
`dependent-sum < 0.6.2.2` defines its own version of `Data.GADT.Compare`, which conflicts with the version of the module that comes with `some`.

This leads to some very confusing type errors that took me an embarrassing amount of time to figure out.
