### PR TITLE
Use StrictData for lsp-types

### DIFF
--- a/lsp-types/lsp-types.cabal
+++ b/lsp-types/lsp-types.cabal
@@ -91,6 +91,7 @@ library
                      , unordered-containers
   hs-source-dirs:      src
   default-language:    Haskell2010
+  default-extensions: StrictData
 
 source-repository head
   type:     git

--- a/lsp-types/src/Data/IxMap.hs
+++ b/lsp-types/src/Data/IxMap.hs
@@ -3,10 +3,11 @@
 {-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ViewPatterns     #-}
+{-# LANGUAGE BangPatterns     #-}
 
 module Data.IxMap where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Some
 import Data.Kind
 import Unsafe.Coerce
@@ -36,5 +37,5 @@ lookupIxMap i (IxMap m) =
 pickFromIxMap :: IxOrd k => k m -> IxMap k f -> (Maybe (f m), IxMap k f)
 pickFromIxMap i (IxMap m) =
   case M.updateLookupWithKey (\_ _ -> Nothing) (toBase i) m of
-    (Nothing,m') -> (Nothing,IxMap m')
-    (Just (Some k),m') -> (Just (unsafeCoerce k),IxMap m')
+    (Nothing,!m') -> (Nothing,IxMap m')
+    (Just (Some k),!m') -> (Just (unsafeCoerce k),IxMap m')

--- a/lsp-types/src/Language/LSP/Types/Initialize.hs
+++ b/lsp-types/src/Language/LSP/Types/Initialize.hs
@@ -51,8 +51,6 @@ makeExtendingDatatype "InitializeParams" [''WorkDoneProgressParams]
   , ("_workspaceFolders",      [t| Maybe (List WorkspaceFolder) |])
   ]
 
-{-# DEPRECATED _rootPath "Use _rootUri" #-}
-
 deriveJSON lspOptions ''InitializeParams
 
 data InitializeError =

--- a/lsp-types/src/Language/LSP/Types/TextDocument.hs
+++ b/lsp-types/src/Language/LSP/Types/TextDocument.hs
@@ -162,12 +162,12 @@ makeExtendingDatatype "TextDocumentChangeRegistrationOptions"
 
 deriveJSON lspOptions ''TextDocumentChangeRegistrationOptions
 
-{-# DEPRECATED _rangeLength "Use _range instead" #-}
 data TextDocumentContentChangeEvent =
   TextDocumentContentChangeEvent
     { -- | The range of the document that changed.
       _range       :: Maybe Range
       -- | The optional length of the range that got replaced.
+      -- Deprecated, use _range instead
     , _rangeLength :: Maybe Int
       -- | The new text for the provided range, if provided.
       -- Otherwise the new text of the whole document.

--- a/lsp-types/src/Language/LSP/VFS.hs
+++ b/lsp-types/src/Language/LSP/VFS.hs
@@ -48,7 +48,7 @@ import qualified Data.Text as T
 import           Data.List
 import           Data.Ord
 import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Rope.UTF16 ( Rope )
 import qualified Data.Rope.UTF16 as Rope

--- a/src/Language/LSP/Diagnostics.hs
+++ b/src/Language/LSP/Diagnostics.hs
@@ -21,7 +21,7 @@ module Language.LSP.Diagnostics
   ) where
 
 import qualified Data.SortedList as SL
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.HashMap.Strict as HM
 import qualified Language.LSP.Types      as J
 

--- a/src/Language/LSP/Server/Control.hs
+++ b/src/Language/LSP/Server/Control.hs
@@ -81,7 +81,7 @@ runServerWith ::
     -> IO Int         -- exit code
 runServerWith clientIn clientOut serverDefinition = do
 
-  infoM "haskell-lsp.runWith" "\n\n\n\n\nhaskell-lsp:Starting up server ..."
+  infoM "lsp.runWith" "\n\n\n\n\nlsp:Starting up server ..."
 
   cout <- atomically newTChan :: IO (TChan J.Value)
   _rhpid <- forkIO $ sendServer cout clientOut
@@ -108,7 +108,7 @@ ioLoop clientIn serverDefinition vfs sendMsg = do
     Just (msg,remainder) -> do
       case J.eitherDecode $ BSL.fromStrict msg of
         Left err ->
-          errorM "haskell-lsp.ioLoop" $
+          errorM "lsp.ioLoop" $
             "Got error while decoding initialize:\n" <> err <> "\n exiting 1 ...\n"
         Right initialize -> do
           mInitResp <- initializeRequestHandler serverDefinition vfs sendMsg initialize
@@ -119,7 +119,7 @@ ioLoop clientIn serverDefinition vfs sendMsg = do
 
     parseOne :: Result BS.ByteString -> IO (Maybe (BS.ByteString,BS.ByteString))
     parseOne (Fail _ ctxs err) = do
-      errorM "haskell-lsp.parseOne" $
+      errorM "lsp.parseOne" $
         "Failed to parse message header:\n" <> intercalate " > " ctxs <> ": " <>
         err <> "\n exiting 1 ...\n"
       pure Nothing
@@ -127,11 +127,11 @@ ioLoop clientIn serverDefinition vfs sendMsg = do
       bs <- clientIn
       if BS.null bs
         then do
-          errorM "haskell-lsp.parseON" "haskell-lsp:Got EOF, exiting 1 ...\n"
+          errorM "lsp.parseON" "lsp:Got EOF, exiting 1 ...\n"
           pure Nothing
         else parseOne (c bs)
     parseOne (Done remainder msg) = do
-      debugM "haskell-lsp.parseOne" $ "---> " <> T.unpack (T.decodeUtf8 msg)
+      debugM "lsp.parseOne" $ "---> " <> T.unpack (T.decodeUtf8 msg)
       pure $ Just (msg,remainder)
 
     loop env = go
@@ -168,7 +168,7 @@ sendServer msgChan clientOut = do
                 , str ]
 
     clientOut out
-    debugM "haskell-lsp.sendServer" $ "<--2--" <> TL.unpack (TL.decodeUtf8 str)
+    debugM "lsp.sendServer" $ "<--2--" <> TL.unpack (TL.decodeUtf8 str)
 
 -- |
 --

--- a/src/Language/LSP/Server/Core.hs
+++ b/src/Language/LSP/Server/Core.hs
@@ -48,7 +48,7 @@ import qualified Data.HashMap.Strict as HM
 import           Data.Kind
 import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import qualified Data.Text as T
 import           Data.Text ( Text )

--- a/src/Language/LSP/Server/Processing.hs
+++ b/src/Language/LSP/Server/Processing.hs
@@ -38,7 +38,7 @@ import System.Log.Logger
 import qualified Data.Dependent.Map as DMap
 import Data.Maybe
 import Data.Dependent.Map (DMap)
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import System.Exit
 
 processMessage :: BSL.ByteString -> LspM config ()
@@ -63,7 +63,7 @@ processMessage jsonStr = do
     handleErrors = either (sendErrorLog . errMsg) id
 
     errMsg err = TL.toStrict $ TL.unwords
-      [ "haskell-lsp:incoming message parse error."
+      [ "lsp:incoming message parse error."
       , TL.decodeUtf8 jsonStr
       , TL.pack err
       ] <> "\n"
@@ -310,7 +310,7 @@ handle' mAction m msg = do
       Nothing
         | SShutdown <- m -> liftIO $ shutdownRequestHandler msg (mkRspCb msg)
         | otherwise -> do
-            let errorMsg = T.pack $ unwords ["haskell-lsp:no handler for: ", show m]
+            let errorMsg = T.pack $ unwords ["lsp:no handler for: ", show m]
                 err = ResponseError MethodNotFound errorMsg Nothing
             sendToClient $
               FromServerRsp (msg ^. LSP.method) $ ResponseMessage "2.0" (Just (msg ^. LSP.id)) (Left err)
@@ -322,7 +322,7 @@ handle' mAction m msg = do
       ReqMess req -> case pickHandler dynReqHandlers reqHandlers of
         Just h -> liftIO $ h req (mkRspCb req)
         Nothing -> do
-          let errorMsg = T.pack $ unwords ["haskell-lsp:no handler for: ", show m]
+          let errorMsg = T.pack $ unwords ["lsp:no handler for: ", show m]
               err = ResponseError MethodNotFound errorMsg Nothing
           sendToClient $
             FromServerRsp (req ^. LSP.method) $ ResponseMessage "2.0" (Just (req ^. LSP.id)) (Left err)
@@ -342,7 +342,7 @@ handle' mAction m msg = do
     reportMissingHandler
       | isOptionalNotification m = return ()
       | otherwise = do
-          let errorMsg = T.pack $ unwords ["haskell-lsp:no handler for: ", show m]
+          let errorMsg = T.pack $ unwords ["lsp:no handler for: ", show m]
           sendErrorLog errorMsg
     isOptionalNotification (SCustomMethod method)
       | "$/" `T.isPrefixOf` method = True
@@ -374,7 +374,7 @@ handleConfigChange req = do
   case res of
     Left err -> do
       let msg = T.pack $ unwords
-            ["haskell-lsp:configuration parse error.", show req, show err]
+            ["lsp:configuration parse error.", show req, show err]
       sendErrorLog msg
     Right () -> pure ()
 
@@ -382,7 +382,7 @@ vfsFunc :: (VFS -> b -> (VFS, [String])) -> b -> LspM config ()
 vfsFunc modifyVfs req = do
   join $ stateState resVFS $ \(VFSData vfs rm) ->
     let (!vfs', ls) = modifyVfs vfs req
-    in (liftIO $ mapM_ (debugM "haskell-lsp.vfsFunc") ls,VFSData vfs' rm)
+    in (liftIO $ mapM_ (debugM "lsp.vfsFunc") ls,VFSData vfs' rm)
 
 -- | Updates the list of workspace folders
 updateWorkspaceFolders :: Message WorkspaceDidChangeWorkspaceFolders -> LspM config ()


### PR DESCRIPTION
Also added a few strictness annotations and replaced the use of
`Data.Map` with `Data.Map.Strict`

Removed a few depreceated warnings of some fields because it is impossible to
create those records without triggering the warnings.
