### PR TITLE
Add some missing Completion-related features

### DIFF
--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -140,6 +140,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
       (Just True)
       (since 3 9 True)
       (since 3 15 completionItemTagsCapabilities)
+      (since 3 16 True)
 
     completionItemKindCapabilities =
       CompletionItemKindClientCapabilities (Just ciKs)

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -141,6 +141,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
       (since 3 9 True)
       (since 3 15 completionItemTagsCapabilities)
       (since 3 16 True)
+      (since 3 16 (CompletionItemInsertTextModeClientCapabilities (List [])))
 
     completionItemKindCapabilities =
       CompletionItemKindClientCapabilities (Just ciKs)

--- a/lsp-types/src/Language/LSP/Types/Capabilities.hs
+++ b/lsp-types/src/Language/LSP/Types/Capabilities.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Language.LSP.Types.Capabilities
   (
     module Language.LSP.Types.ClientCapabilities
@@ -141,6 +142,7 @@ capsForVersion (LSPVersion maj min) = ClientCapabilities (Just w) (Just td) (Jus
       (since 3 9 True)
       (since 3 15 completionItemTagsCapabilities)
       (since 3 16 True)
+      (since 3 16 (CompletionItemResolveClientCapabilities (List ["documentation", "details"])))
       (since 3 16 (CompletionItemInsertTextModeClientCapabilities (List [])))
 
     completionItemKindCapabilities =

--- a/lsp-types/src/Language/LSP/Types/Completion.hs
+++ b/lsp-types/src/Language/LSP/Types/Completion.hs
@@ -119,6 +119,14 @@ data CompletionItemTagsClientCapabilities =
 
 deriveJSON lspOptions ''CompletionItemTagsClientCapabilities
 
+data CompletionItemResolveClientCapabilities =
+  CompletionItemResolveClientCapabilities
+    { -- | The properties that a client can resolve lazily.
+      _valueSet :: List Text
+    } deriving (Show, Read, Eq)
+
+deriveJSON lspOptions ''CompletionItemResolveClientCapabilities
+
 {-|
 How whitespace and indentation is handled during completion
 item insertion.
@@ -193,6 +201,12 @@ data CompletionItemClientCapabilities =
       --
       -- @since 3.16.0
     , _insertReplaceSupport :: Maybe Bool
+      -- | Indicates which properties a client can resolve lazily on a
+      -- completion item. Before version 3.16.0 only the predefined properties
+      -- `documentation` and `details` could be resolved lazily.
+      --
+      -- @since 3.16.0
+    , _resolveSupport :: Maybe CompletionItemResolveClientCapabilities
       -- | The client supports the `insertTextMode` property on
       -- a completion item to override the whitespace handling mode
       -- as defined by the client (see `insertTextMode`).

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -123,6 +123,7 @@ makeFieldsNoPrefix ''CompletionParams
 makeFieldsNoPrefix ''CompletionOptions
 makeFieldsNoPrefix ''CompletionRegistrationOptions
 makeFieldsNoPrefix ''CompletionItemTagsClientCapabilities
+makeFieldsNoPrefix ''CompletionItemInsertTextModeClientCapabilities
 makeFieldsNoPrefix ''CompletionItemClientCapabilities
 makeFieldsNoPrefix ''CompletionItemKindClientCapabilities
 makeFieldsNoPrefix ''CompletionClientCapabilities

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -115,6 +115,7 @@ makeFieldsNoPrefix ''LocationLink
 makeFieldsNoPrefix ''MarkupContent
 
 -- Completion
+makeFieldsNoPrefix ''InsertReplaceEdit
 makeFieldsNoPrefix ''CompletionItem
 makeFieldsNoPrefix ''CompletionContext
 makeFieldsNoPrefix ''CompletionList

--- a/lsp-types/src/Language/LSP/Types/Lens.hs
+++ b/lsp-types/src/Language/LSP/Types/Lens.hs
@@ -123,6 +123,7 @@ makeFieldsNoPrefix ''CompletionParams
 makeFieldsNoPrefix ''CompletionOptions
 makeFieldsNoPrefix ''CompletionRegistrationOptions
 makeFieldsNoPrefix ''CompletionItemTagsClientCapabilities
+makeFieldsNoPrefix ''CompletionItemResolveClientCapabilities
 makeFieldsNoPrefix ''CompletionItemInsertTextModeClientCapabilities
 makeFieldsNoPrefix ''CompletionItemClientCapabilities
 makeFieldsNoPrefix ''CompletionItemKindClientCapabilities


### PR DESCRIPTION
- `InsertReplaceTextEdit`
    - Needs a new type, I put it in the `Completion` module since it's grouped with those types in the spec.
- `InsertMode`
    - Straightforward enum
- `resolveSupport`
    - It looks like we already have methods for this, we just didn't have the client capability listed.