### PR TITLE
Fix applying a TextEdit past the end of the document

### DIFF
--- a/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
+++ b/lsp-types/src/Language/LSP/Types/WorkspaceEdit.hs
@@ -274,6 +274,9 @@ applyTextEdit (TextEdit (Range sp ep) newText) oldText =
   where
     splitAtPos :: Position -> Text -> (Text, Text)
     splitAtPos (Position sl sc) t =
+      -- If we are looking for a line beyond the end of the text, this will give us an index
+      -- past the end. Fortunately, T.splitAt is fine with this, and just gives us the whole
+      -- string and an empty string, which is what we want.
       let index = sc + startLineIndex sl t
         in T.splitAt index t
 
@@ -282,7 +285,9 @@ applyTextEdit (TextEdit (Range sp ep) newText) oldText =
     startLineIndex line t' =
       case T.findIndex (== '\n') t' of
         Just i -> i + 1 + startLineIndex (line - 1) (T.drop (i + 1) t')
-        Nothing -> 0
+        -- i != 0, and there are no newlines, so this is a line beyond the end of the text.
+        -- In this case give the "start index" as the end, so we will at least append the text.
+        Nothing -> T.length t'
 
 -- | 'editTextEdit' @outer@ @inner@ applies @inner@ to the text inside @outer@.
 editTextEdit :: TextEdit -> TextEdit -> TextEdit

--- a/test/WorkspaceEditSpec.hs
+++ b/test/WorkspaceEditSpec.hs
@@ -16,6 +16,9 @@ spec = do
     it "edits a multiline text" $
       let te = TextEdit (Range (Position 1 0) (Position 2 0)) "slorem"
         in applyTextEdit te "lorem\nipsum\ndolor" `shouldBe` "lorem\nsloremdolor"
+    it "inserts text past the last line" $
+      let te = TextEdit (Range (Position 3 2) (Position 3 2)) "foo"
+        in applyTextEdit te "lorem\nipsum\ndolor" `shouldBe` "lorem\nipsum\ndolorfoo"
 
   describe "editTextEdit" $
     it "edits a multiline text edit" $


### PR DESCRIPTION
A simple fix, the text gets appended. You could imagine being smarter
here, but at least it doesn't insert it into the existing text as it
would before.

Fixes #271.